### PR TITLE
Fix for selecter issue on Android

### DIFF
--- a/js/formstone.js
+++ b/js/formstone.js
@@ -3,6 +3,10 @@ Drupal.behaviors.formstone = {};
 Drupal.behaviors.formstone.attach = function(context, settings) {
   if ($.fn.selecter) {
     $('.webform-client-form select', context).selecter();
+    // fix for selecter not working on Android 6+ and Android Chrome 50+
+    if (navigator.userAgent.match(/Android (\d+)\./i)) {
+      $('.selecter').css('pointer-events', 'none');
+    }
   }
   if ($.fn.picker) {
     $('.webform-client-form input[type=checkbox]', context).picker();


### PR DESCRIPTION
Adds a workaround for selecter options no longer showing on mobiles using Android 6+ or Android Chrome 50+.
