### PR TITLE
Remove webform-ajax-scroll as it is now part of campaignion_ux.

### DIFF
--- a/morelesszen_starterkit/js/morelesszen_starterkit.js
+++ b/morelesszen_starterkit/js/morelesszen_starterkit.js
@@ -1,29 +1,6 @@
 (function($) {
 Drupal.behaviors.morelesszen_starterkit = {};
 Drupal.behaviors.morelesszen_starterkit.attach = function(context, settings) {
-  // scroll to top of form + padding if we are below it
-  // or if we are more than the toleratedOffset above it
-  if ('ajax' in settings) {
-    $.each(settings.ajax, function(el) {
-      var padding = 12;
-      var toleratedOffset = 50;
-      if (el && Drupal.ajax[el]) {
-        var oldsuccess = Drupal.ajax[el].success;
-
-        Drupal.ajax[el].success = function (response, status) {
-          oldsuccess.call(this, response, status);
-          var wrapperTop = $('#' + settings.ajax[el].wrapper).offset().top;
-          var diff = Math.abs(wrapperTop) - (Math.abs($('html').offset().top) || $('html')[0].scrollTop); // get scroll position across browsers
-          if (diff < 0 || Math.abs(diff) > toleratedOffset) {
-            // IE scrolls html, not body.
-            var $scrollEl = $('body')[0].scrollTop === 0 ? $('html') : $('body');
-            $scrollEl.animate({ scrollTop: (wrapperTop - padding)}, 'slow');
-          }
-        }
-      }
-    });
-  }
-
   // container id begins with webform-ajax-wrapper
   $('.webform-client-form', context).webformAjaxSlide({
     loadingDummyMsg: Drupal.t('loading'),


### PR DESCRIPTION
It’s now in campaignion_ux: https://github.com/moreonion/campaignion/pull/43