### PR TITLE
Fix picker missing checked class

### DIFF
--- a/js/formstone.js
+++ b/js/formstone.js
@@ -32,6 +32,10 @@ Drupal.behaviors.formstone.attach = function(context, settings) {
         mutations.forEach(function (mutation) {
           if (mutation.target.disabled != $(mutation.target).data("previousDisabled")){
             formstoneFunction.call($(mutation.target), mutation.target.disabled ? "disable" : "enable");
+            if (formstoneFunction === $.fn.picker) {
+              // enabling the picker does not set a checked class, update is needed as well.
+              formstoneFunction.call($(mutation.target), "update");
+            }
             $(mutation.target).data("previousDisabled", mutation.target.disabled);
           }
         });


### PR DESCRIPTION
Adds a fix missing in https://github.com/moreonion/morelesszen/pull/8

When a formstone picker element is set disabled, it looses its checked styles – but they are not added when enabling it. It’s necessary to call "update" as well to make a newly enabled checked picker element actually display as checked.