### PR TITLE
Fix UA match for Android 9

### DIFF
--- a/js/formstone.js
+++ b/js/formstone.js
@@ -7,7 +7,7 @@ Drupal.behaviors.formstone.attach = function(context, settings) {
     fixDisabledState($selects, $.fn.selecter, ".selecter");
 
     // fix for selecter not working on Android 6+ and Android Chrome 50+
-    if (navigator.userAgent.match(/Android (\d+)\./i)) {
+    if (navigator.userAgent.match(/Android (\d+)/i)) {
       $('.selecter').css('pointer-events', 'none');
     }
   }


### PR DESCRIPTION
- selecter optout for Android was broken

The UA string does not necessarily include a `.` in the Android version string any more