### PR TITLE
Make sure metatags for a page are always rendered.

### DIFF
--- a/template.php
+++ b/template.php
@@ -200,6 +200,20 @@ function morelesszen_preprocess_page(&$vars) {
 }
 
 /**
+ * Process template variables before a page is rendered.
+ *
+ * Ensures that metatags are rendered regardless of whether the template
+ * actually renders the region (or any region).
+ */
+function morelesszen_process_page(&$vars) {
+  // Render metatags even if we don’t render the $page[$region].
+  $region = variable_get('metatag_page_region', 'content');
+  if (!empty($vars['page'][$region]['metatags'])) {
+    render($vars['page'][$region]['metatags']);
+  }
+}
+
+/**
  * Implements template_preprocess_maintenance_page().
  */
 function morelesszen_preprocess_maintenance_page(&$vars) {


### PR DESCRIPTION
In some templates (page.tpl.php) not all regions are rendered always. Instead of trying to find a region that is always rendered this change makes sure the metatags #attached values are processed regardless of
which regions are rendered.