### PR TITLE
 Fix for rendering metatags regardless of region.

### DIFF
--- a/htaccess
+++ b/htaccess
@@ -27,7 +27,7 @@ ServerSignature Off
 # Cross-domain AJAX requests
 # ----------------------------------------------------------------------
 
-# Serve cross-domain ajax requests, disabled.   
+# Serve cross-domain ajax requests, disabled.
 # enable-cors.org
 # code.google.com/p/html5security/wiki/CrossOriginRequestSecurity
 

--- a/settings_tweak
+++ b/settings_tweak
@@ -5,7 +5,7 @@ $exts = 'txt|png|gif|jpe?g|shtml?|css|js|ico|swf|flv|cgi|bat|pl|dll|exe|asp|xml'
 if (!strpos($_SERVER['QUERY_STRING'], 'imagecache') && !strpos($_SERVER['QUERY_STRING'], '/advagg_')) {
   // It is not our main feed page
   if ($_SERVER['QUERY_STRING'] != 'rss.xml') {
-    // Is it a static file? 
+    // Is it a static file?
     if (preg_match('/\.(' . $exts . ')$/', $_SERVER['QUERY_STRING']))
       // Just send a 404 right now ...
       {

--- a/template.php
+++ b/template.php
@@ -75,7 +75,7 @@ function morelesszen_preprocess(&$vars, $hook) {
  * Implements template_preprocess_html().
  */
 function morelesszen_preprocess_html(&$vars) {
-  
+
   $vars['doctype'] = _morelesszen_doctype();
   $vars['rdf'] = _morelesszen_rdf($vars);
 
@@ -204,7 +204,7 @@ function morelesszen_preprocess_page(&$vars) {
     // Make sure the shortcut link is the first item in title_suffix.
     $vars['title_suffix']['add_or_remove_shortcut']['#weight'] = -100;
   }
-  
+
   if(!theme_get_setting('morelesszen_feed_icons')) {
     $vars['feed_icons'] = '';
   }
@@ -272,11 +272,11 @@ function morelesszen_preprocess_node(&$vars) {
   if ($vars['uid'] && $vars['uid'] === $GLOBALS['user']->uid) {
     $classes[] = 'node-mine'; // Node is authored by current user.
   }
-  
+
   $vars['submitted'] = t('Submitted by !username on ', array('!username' => $vars['name']));
   $vars['submitted_date'] = t('!datetime', array('!datetime' => $vars['date']));
   $vars['submitted_pubdate'] = format_date($vars['created'], 'custom', 'Y-m-d\TH:i:s');
-  
+
   if ($vars['view_mode'] == 'full' && node_is_page($vars['node'])) {
     $vars['classes_array'][] = 'node-full';
   }
@@ -330,15 +330,15 @@ function morelesszen_field__taxonomy_term_reference($vars) {
  *  Return a themed breadcrumb trail
  */
 function morelesszen_breadcrumb($vars) {
-  
+
   $breadcrumb = isset($vars['breadcrumb']) ? $vars['breadcrumb'] : array();
-  
+
   if (theme_get_setting('morelesszen_breadcrumb_hideonlyfront')) {
     $condition = count($breadcrumb) > 1;
   } else {
     $condition = !empty($breadcrumb);
   }
-  
+
   if(theme_get_setting('morelesszen_breadcrumb_showtitle')) {
     $title = drupal_get_title();
     if(!empty($title)) {
@@ -346,13 +346,13 @@ function morelesszen_breadcrumb($vars) {
       $breadcrumb[] = $title;
     }
   }
-  
+
   $separator = theme_get_setting('morelesszen_breadcrumb_separator');
 
   if (!$separator) {
     $separator = '»';
   }
-  
+
   if ($condition) {
     return implode(" {$separator} ", $breadcrumb);
   }
@@ -558,7 +558,7 @@ function morelesszen_preprocess_menu_link(&$variables) {
 /**
  * Implements template_preprocess_field() for main pic/vid
  */
- 
+
 function morelesszen_field__image($variables) {
   $output = '';
 

--- a/template.php
+++ b/template.php
@@ -216,11 +216,11 @@ function morelesszen_preprocess_page(&$vars) {
  * Ensures that metatags are rendered regardless of whether the template
  * actually renders the region (or any region).
  */
-function morelesszen_process_page(&$vars) {
+function morelesszen_page_alter($page) {
   // Render metatags even if we don’t render the $page[$region].
   $region = variable_get('metatag_page_region', 'content');
-  if (!empty($vars['page'][$region]['metatags'])) {
-    render($vars['page'][$region]['metatags']);
+  if (!empty($page[$region]['metatags'])) {
+    render($page[$region]['metatags']);
   }
 }
 

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -5,7 +5,7 @@
  * Theme settings for the Zentropy
  */
 function morelesszen_form_system_theme_settings_alter(&$form, &$form_state) {
-  
+
   /**
    * General Settings
    */
@@ -58,7 +58,7 @@ function morelesszen_form_system_theme_settings_alter(&$form, &$form_state) {
     '#title' => t('Hide the breadcrumb if the breadcrumb only contains the link to the front page.'),
     '#default_value' => theme_get_setting('morelesszen_breadcrumb_hideonlyfront'),
   );
-  
+
   $form['morelesszen_breadcrumb']['morelesszen_breadcrumb_showtitle'] = array(
     '#type' => 'checkbox',
     '#title' => t('Show page title on breadcrumb.'),
@@ -81,19 +81,19 @@ function morelesszen_form_system_theme_settings_alter(&$form, &$form_state) {
     '#type' => 'fieldset',
     '#title' => t('Google Analytics'),
   );
-  
+
   $form['morelesszen_ga']['morelesszen_ga_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable Google Analytics'),
     '#default_value' => theme_get_setting('morelesszen_ga_enable'),
   );
-  
+
   $form['morelesszen_ga']['morelesszen_ga_trackingcode'] = array(
     '#type' => 'textfield',
     '#title' => t('Tracking code'),
     '#default_value' => theme_get_setting('morelesszen_ga_trackingcode'),
   );
-  
+
   $form['morelesszen_ga']['morelesszen_ga_trackroles'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Exclude roles'),
@@ -101,7 +101,7 @@ function morelesszen_form_system_theme_settings_alter(&$form, &$form_state) {
     '#description' => t('Exclude the following roles from being tracked'),
     '#default_value' => !empty($roles_tracked) ? array_values((array) $roles_tracked) : array(),
   );
-  
+
   $form['morelesszen_ga']['morelesszen_ga_anonimize'] = array(
     '#type' => 'checkbox',
     '#title' => t('Anonimize IP'),


### PR DESCRIPTION
Follow-up of https://github.com/moreonion/morelesszen/pull/20.

It seems an empty region is completely empty in `hook_(pre)process_page()`, but in `hook_page_alter()` the metatags are still there.