### PR TITLE
Improve filer.

### DIFF
--- a/js/formstone.js
+++ b/js/formstone.js
@@ -33,7 +33,11 @@ Drupal.behaviors.formstone.attach = function(context, settings) {
     //   as context.
     var $uploads = $('input[type=file]', context).filter(function() {
       return $(this).closest('.filer').length == 0 && $(this).closest('form').is('.webform-client-form');
-    }).filer();
+    }).filer().on('change', function() {
+      $(this).closest('.form-managed-file').find('[type=submit]').mousedown();
+    }).each(function() {
+      $(this).closest('.form-managed-file').find('[type=submit]').hide();
+    });
     fixDisabledState($uploads, $.fn.filer, ".filer");
   }
 

--- a/js/formstone.js
+++ b/js/formstone.js
@@ -26,7 +26,14 @@ Drupal.behaviors.formstone.attach = function(context, settings) {
   }
 
   if ($.fn.filer) {
-    var $uploads = $('.webform-client-form input[type=file]', context).filer();
+    // Add filer to all file uploads in webforms.
+    // - Do this even when only part of the form are AJAX replaced. This means
+    //   the context is a sub-element of the form.
+    // - Avoid doing it twice when the behavior gets an extra call with the form
+    //   as context.
+    var $uploads = $('input[type=file]', context).filter(function() {
+      return $(this).closest('.filer').length == 0 && $(this).closest('form').is('.webform-client-form');
+    }).filer();
     fixDisabledState($uploads, $.fn.filer, ".filer");
   }
 

--- a/js/formstone.js
+++ b/js/formstone.js
@@ -34,7 +34,10 @@ Drupal.behaviors.formstone.attach = function(context, settings) {
     var $uploads = $('input[type=file]', context).filter(function() {
       return $(this).closest('.filer').length == 0 && $(this).closest('form').is('.webform-client-form');
     }).filer().on('change', function() {
-      $(this).closest('.form-managed-file').find('[type=submit]').mousedown();
+      var $widget = $(this).closest('.form-managed-file');
+      if ($widget.find('.file-upload-js-error').length <= 0) {
+        $widget.find('[type=submit]').mousedown();
+      }
     }).each(function() {
       $(this).closest('.form-managed-file').find('[type=submit]').hide();
     });

--- a/js/jquery.fs.filer.js
+++ b/js/jquery.fs.filer.js
@@ -131,7 +131,6 @@ if (jQuery) (function($) {
 	// Handle update
 	function _update(e) {
 		e.preventDefault();
-		e.stopPropagation();
 		
 		var data = e.data;
 		


### PR DESCRIPTION
- Fix attaching. It needs to work in multiple cases:
   1. The first load of a form: Usually with `context === document`.
   2. Navigating between form steps: context is the webform ajax wrapper.
   3. When removing an uploaded file: context is a div around the form field.
   4. After 3. the behaviour is attached again on the entire form. Then we must avoid to attach the filer twice. (see Drupal.ajax.prototype.success)
- Don’t prevent other JS from reacting to change events.
- Auto-upload + hide upload button.